### PR TITLE
v 6.5.1  - Add cl appgroup feature, tf state and priority

### DIFF
--- a/dpconfig_mapper.py
+++ b/dpconfig_mapper.py
@@ -216,7 +216,7 @@ class DataMapper():
 									connlim_action = 'N/A in this version'
 
 
-								connlim_prot_values = connlim_prot_values + f'Protection Name: {connlim_prof_prot["rsIDSConnectionLimitAttackName"]}\r\nProtection ID: {connlim_prof_prot["rsIDSConnectionLimitAttackId"]}\r\nProtection Type: {connlim_type}\r\nProtocol: {connlim_protoctol}\r\nThreshold: {connlim_prof_prot["rsIDSConnectionLimitAttackThreshold"]}\r\nTracking Type: {connlim_tracking_type}\r\nAction: {connlim_action}\r\nPacket Reporting: {connlim_reporting}\r\n------\r\n'
+								connlim_prot_values = connlim_prot_values + f'Protection Name: {connlim_prof_prot["rsIDSConnectionLimitAttackName"]}\r\nProtection ID: {connlim_prof_prot["rsIDSConnectionLimitAttackId"]}\r\nProtection Type: {connlim_type}\r\nProtocol: {connlim_protoctol}\r\nApplication Port: {connlim_prof_prot["rsIDSConnectionLimitAttackAppPort"]}\r\nThreshold: {connlim_prof_prot["rsIDSConnectionLimitAttackThreshold"]}\r\nTracking Type: {connlim_tracking_type}\r\nAction: {connlim_action}\r\nPacket Reporting: {connlim_reporting}\r\n------\r\n'
 
 							connlim_settings.append(connlim_prot_values)
 		return connlim_settings
@@ -323,6 +323,19 @@ class DataMapper():
 
 									tf_rules += f'Rule Name: {tf_prof_rule["rsNewTrafficFilterName"]}'
 									tf_rules += f'\r\nProtection ID: {tf_prof_rule["rsNewTrafficFilterID"]}'
+
+									# Rule Enabled/Disabled
+									if 'rsNewTrafficFilterState' in tf_prof_rule: # Show rule enabled or disabled:
+										if tf_prof_rule['rsNewTrafficFilterState'] == '1':
+											tf_enabled = 'Enabled'
+										else:
+											tf_enabled = 'Disabled'
+										tf_rules += f'\r\nRule State: {tf_enabled}'			
+
+									# Rule Priority
+									if 'rsNewTrafficFilterPriority' in tf_prof_rule: # Show rule priority:
+										tf_priority = tf_prof_rule['rsNewTrafficFilterPriority']
+										tf_rules += f'\r\nRule Priority: {tf_priority}'									
 
 									# FILTER MODE
 									if 'rsNewTrafficFilterMatchCriteria' in tf_prof_rule: # Apply Traffic Filter To:

--- a/readme.MD
+++ b/readme.MD
@@ -438,6 +438,10 @@ V6.2.4.2
 V6.3 (10/11/24)
 	- Added policy priority mapping
 
+V6.3.1 (3/31/25)
+
+	- Fixed a bug to send low baselines report over email
+
 V6.4 (5/9/2025)
 	- Added reauthentication logic if JSESSIONID has expired
 
@@ -457,10 +461,6 @@ V6.5.1 (5/19/25 - Cris)
 2 - review, map each key/value and decide what needs to be mapped and how (how many columns, how exactly)
 3 - get the data through API call
 4 - parse the output and map to csv
-
-V6.3.1 (3/31/25)
-
-	- Fixed a bug to send low baselines report over email
 
 -------------------------------
 

--- a/readme.MD
+++ b/readme.MD
@@ -444,6 +444,12 @@ V6.4 (5/9/2025)
 V6.5 (5/12/2025)
 	- Fixed an issue with data collection, there was unnecessary loop which was causing the script to stuck when many DefensePro selected
 
+V6.5.1 (5/19/25 - Cris)
+	- More information added for:
+		- Traffic filters rules: Rule State (Enabled/Disabled) and Rule Priority
+		- Connection Limit Profile: Application Port 
+	Note: TF Rules are not displayed in the csv in the priority order.
+
 # Functionality planned to be added:
 
 - HTTPS flood protection mapping


### PR DESCRIPTION
- More information added for:
		- Traffic filters rules: Rule State (Enabled/Disabled) and Rule Priority
		- Connection Limit Profile: Application Port 
	Note: TF Rules are not displayed in the csv in the priority order.